### PR TITLE
fix: allow commands with spaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,3 +32,13 @@ workflows:
           requires:
             - release-management/test-package
           tag: core-v1
+  dependabot-automerge:
+    triggers:
+      - schedule:
+          cron: '0 2,5,8,11 * * *'
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - release-management/dependabot-automerge

--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -5,7 +5,7 @@ export default class Which extends Command {
   static description = 'Show which plugin a command is in.'
   static strict = false;
 
-  async run() {
+  async run(): Promise<void> {
     const {argv} = await this.parse(Which)
     const cmd = this.config.findCommand(argv.join(':'), {must: true})
     ux.styledHeader(cmd.id)

--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -2,13 +2,12 @@ import {Command} from '@oclif/core'
 import ux from 'cli-ux'
 
 export default class Which extends Command {
-  static description = 'show which plugin a command is in'
-
-  static args = [{name: 'command', required: true}]
+  static description = 'Show which plugin a command is in.'
+  static strict = false;
 
   async run() {
-    const {args} = await this.parse(Which)
-    const cmd = this.config.findCommand(args.command, {must: true})
+    const {argv} = await this.parse(Which)
+    const cmd = this.config.findCommand(argv.join(':'), {must: true})
     ux.styledHeader(cmd.id)
     ux.styledObject({
       plugin: cmd.pluginName,


### PR DESCRIPTION
Accept either commands with colons or commands with spaces

with colons:
```
~ [] : sf which env:list
=== env:list
plugin: @salesforce/plugin-env
```

with spaces:
```
~ [] : sf which env list
=== env:list
plugin: @salesforce/plugin-env
```

@W-10260953@