### PR TITLE
fix: add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
     "lint": "eslint . --ext .ts --config .eslintrc",
     "pretest": "yarn build && tsc -p test --noEmit",
     "build": "rm -rf lib && tsc"
-  }
+  },
+  "main": "lib/index.js"
 }


### PR DESCRIPTION
### What does this PR do?

Adds the `main` entry to the package.json in order to improve the performance of module resolution in oclif/core
