### PR TITLE
feat: work with different topicSeparators

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/oclif/plugin-which/issues",
   "dependencies": {
     "@oclif/core": "^1.18.0",
+    "shx": "^0.3.4",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
@@ -46,14 +47,14 @@
   },
   "repository": "oclif/plugin-which",
   "scripts": {
-    "postpack": "rm -f oclif.manifest.json",
+    "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "yarn build && oclif manifest . && oclif readme",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "pretest": "yarn build && tsc -p test --noEmit",
-    "build": "rm -rf lib && tsc"
+    "build": "shx rm -rf lib && tsc"
   },
   "main": "lib/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "bugs": "https://github.com/oclif/plugin-which/issues",
   "dependencies": {
     "@oclif/core": "^1.18.0",
-    "shx": "^0.3.4",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
@@ -23,6 +22,7 @@
     "mocha": "^9",
     "nyc": "^15.1.0",
     "oclif": "^2.6.3",
+    "shx": "^0.3.4",
     "ts-node": "^9.0.0",
     "typescript": "4.6.4"
   },

--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -6,7 +6,7 @@ export default class Which extends Command {
 
   async run(): Promise<void> {
     const {argv} = await this.parse(Which)
-    const cmd = this.config.findCommand(argv.join(':'), {must: true})
+    const cmd = this.config.findCommand(argv.join(this.config.topicSeparator), {must: true})
     CliUx.ux.styledHeader(cmd.id)
     CliUx.ux.styledObject({
       plugin: cmd.pluginName,

--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -6,8 +6,16 @@ export default class Which extends Command {
 
   async run(): Promise<void> {
     const {argv} = await this.parse(Which)
-    const cmd = this.config.findCommand(argv.join(this.config.topicSeparator), {must: true})
-    CliUx.ux.styledHeader(cmd.id)
+    let command = argv
+
+    if (argv.length === 1 && typeof argv[0] === 'string') {
+      // If this if statement is true then the command to find was passed in as a single string, e.g. `mycli which "my command"`
+      // So we must use the topicSeparator to split it into an array
+      command = argv[0].split(this.config.topicSeparator)
+    }
+
+    const cmd = this.config.findCommand(command.join(':'), {must: true})
+    CliUx.ux.styledHeader(command.join(this.config.topicSeparator))
     CliUx.ux.styledObject({
       plugin: cmd.pluginName,
     }, ['plugin'])

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,6 +3408,11 @@ minimist@^1.1.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+minimist@^1.2.3:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
 minipass-collect@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
@@ -4545,6 +4550,14 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shx@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
+  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.5"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Uses the oclif `topicSeparator` setting to find commands instead of defaulting to use `:`.