### PR TITLE
fix: throw error if missing cmd arg

### DIFF
--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -3,6 +3,12 @@ import {Command, CliUx} from '@oclif/core'
 export default class Which extends Command {
   static description = 'Show which plugin a command is in.'
   static strict = false;
+  static examples = [
+    {
+      description: 'See which plugin the `help` command is in:',
+      command: '<%= config.bin %> <%= command.id %> help',
+    },
+  ]
 
   async run(): Promise<void> {
     const {argv} = await this.parse(Which)
@@ -12,6 +18,8 @@ export default class Which extends Command {
       // If this if statement is true then the command to find was passed in as a single string, e.g. `mycli which "my command"`
       // So we must use the topicSeparator to split it into an array
       command = argv[0].split(this.config.topicSeparator)
+    } else {
+      throw new Error('Missing 1 required arg')
     }
 
     const cmd = this.config.findCommand(command.join(':'), {must: true})

--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -19,7 +19,7 @@ export default class Which extends Command {
       // So we must use the topicSeparator to split it into an array
       command = argv[0].split(this.config.topicSeparator)
     } else {
-      throw new Error('Missing 1 required arg')
+      throw new Error('"which" expects a command name.  Try something like "which your:command:here" ')
     }
 
     const cmd = this.config.findCommand(command.join(':'), {must: true})


### PR DESCRIPTION
Makes `which` command throw an error when a command wasn't specified.

Before:

```
➜  plugin-which git:(cd/throw-missing-arg) sfdx which
 ›   Error: command  not found
```

After:
```
➜  plugin-which git:(cd/throw-missing-arg) sfdx which
    Error: Missing 1 required arg
```