### PR TITLE
fix: allows space-separated commands as args

### DIFF
--- a/src/commands/which.ts
+++ b/src/commands/which.ts
@@ -12,14 +12,17 @@ export default class Which extends Command {
 
   async run(): Promise<void> {
     const {argv} = await this.parse(Which)
+
+    if (argv.length === 0) {
+      throw new Error('"which" expects a command name.  Try something like "which your:command:here" ')
+    }
+
     let command = argv
 
     if (argv.length === 1 && typeof argv[0] === 'string') {
       // If this if statement is true then the command to find was passed in as a single string, e.g. `mycli which "my command"`
       // So we must use the topicSeparator to split it into an array
       command = argv[0].split(this.config.topicSeparator)
-    } else {
-      throw new Error('"which" expects a command name.  Try something like "which your:command:here" ')
     }
 
     const cmd = this.config.findCommand(command.join(':'), {must: true})

--- a/test/commands/which.test.ts
+++ b/test/commands/which.test.ts
@@ -7,4 +7,12 @@ describe('which', () => {
   .it('which which', ctx => {
     expect(ctx.stdout).to.contain('@oclif/plugin-which')
   })
+
+  test
+  .stdout()
+  .command(['which'])
+  .catch(error => {
+    expect(error.message).to.contain('"which" expects a command name.  Try something like "which your:command:here" ')
+  })
+  .it('checks arg was provided')
 })


### PR DESCRIPTION
Fix regression introduced by https://github.com/oclif/plugin-which/pull/317

When running `sfdx which force org list` the `which` commands returns:
`Error: "which" expects a command name.  Try something like "which your:command:here"`.

Arg check will happen first now.


[skip-validate-pr]