### PR TITLE
Husky 9.1.1 fix

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname $0)/_/husky.sh"
-
 yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn lint-staged --concurrent false

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-config-oclif": "^5.2.0",
     "eslint-config-oclif-typescript": "^3.1.8",
     "eslint-config-prettier": "^9.1.0",
-    "husky": "^9",
+    "husky": "^9.1.1",
     "lint-staged": "^15",
     "mocha": "^10.6.0",
     "nyc": "^15.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3999,7 +3999,7 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-husky@^9:
+husky@^9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.1.tgz#73f8f1b58329f377654293148c1a6458f54ca224"
   integrity sha512-fCqlqLXcBnXa/TJXmT93/A36tJsjdJkibQ1MuIiFyCCYUlpYpIaj2mv1w+3KR6Rzu1IC3slFTje5f6DUp2A2rg==


### PR DESCRIPTION
Part of [@W-16301617@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16301617)

A Husky regex failed to clean up a change to their hooks. Testing to see if this will resolve our builds 